### PR TITLE
Null to empty string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
-    - "0.6"
-    - "0.8"
-    - "0.10"
+    #- "0.6"
+    #- "0.8"
+    #- "0.10"
     - "4"
-    - "5"
+    - "6"
 
 before_install:
 
@@ -14,7 +14,7 @@ matrix:
         - node_js: "0.6"
 
 after_script:
-    - npm install istanbul codecov.io
+    - npm install istanbul codecov
     - chmod ugo+r ./test/data/noread
-    - NODE_ENV=cov ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- -R spec
-    - cat ./coverage/coverage.json | ./node_modules/codecov.io/bin/codecov.io.js
+    - NODE_ENV=cov ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -R spec
+    - ./node_modules/.bin/codecov

--- a/Changes.md
+++ b/Changes.md
@@ -1,0 +1,4 @@
+
+- 1.0.0 - 2016-12-08
+
+    - replaced null host or user values with empty strings

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,5 +28,6 @@ module.exports = function(grunt) {
         },
     });
 
+    grunt.registerTask('lint', ['eslint']);
     grunt.registerTask('default', ['eslint','mochaTest']);
 };

--- a/index.js
+++ b/index.js
@@ -76,15 +76,15 @@ Address.prototype.parse = function (addr) {
 
     // empty addr is ok
     if (addr === '') {
-        this.user = null;
-        this.host = null;
+        this.user = '';
+        this.host = '';
         return;
     }
 
     // bare postmaster is permissible: RFC-2821 (4.5.1)
     if (addr.toLowerCase() === 'postmaster') {
         this.user = 'postmaster';
-        this.host = null;
+        this.host = '';
         return;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "address-rfc2821",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "RFC 2821 (Envelope) email address parser",
   "author": {
     "name": "The Haraka Team",

--- a/test/address.js
+++ b/test/address.js
@@ -13,11 +13,11 @@ function _check(address, user, host) {
 describe('good addresses pass', function () {
 
     it('<>', function () {
-        _check('<>', null, null);
+        _check('<>', '', '');
     });
 
     it('<postmaster>', function () {
-        _check('<postmaster>', 'postmaster', null);
+        _check('<postmaster>', 'postmaster', '');
     });
 
     it('<foo@example.com>', function () {

--- a/test/address.js
+++ b/test/address.js
@@ -79,3 +79,19 @@ describe('isNull', function () {
         assert.ok(!new Address('<matt@example.com>').isNull());
     });
 });
+
+describe('format()', function () {
+    it('works', function (done) {
+        var addr = new Address('<matt@example.com>');
+        assert.equal(addr.user, 'matt');
+        assert.equal(addr.host, 'example.com');
+        assert.equal(addr.format(), '<matt@example.com>');
+        done();
+    });
+
+    it('lower cases hostnames', function (done) {
+        var addr = new Address('<matt@exAMple.com>');
+        assert.equal(addr.host, 'example.com');
+        done();
+    });
+});


### PR DESCRIPTION
- replace `null` values with empty strings
- only test on node.js 4 & 6
- update codecov syntax

Fixes haraka/Haraka#1737