### PR TITLE
Fix unicode regexs parts to not escape latin chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const punycode = require('punycode');
 
 // a class encapsulating an email address per RFC-2821
 
-const qchar = /([^a-zA-Z0-9!#$%&\x27*+\x2D/=?^_`{|}~.\u00C0-\uFFFF])/;
+const qchar = /([^a-zA-Z0-9!#$%&\x27*+\x2D/=?^_`{|}~.\u00C0-\uFFFF])/g;
 
 function Address (user, host) {
     if (typeof user === 'object' && user.original) {
@@ -51,7 +51,7 @@ exports.domain_expr = undefined;
 
 /* eslint no-control-regex: 0 */
 exports.qtext_expr = /[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F\u00C0-\uFFFF]/;
-exports.text_expr  = /\\([\x01-\x09\x0B\x0C\x0E-\x7F])/;
+exports.text_expr  = /\\([\x01-\x09\x0B\x0C\x0E-\x7F])/g;
 
 let domain_re;
 let source_route_re;
@@ -128,7 +128,7 @@ Address.prototype.parse = function (addr) {
     matches = qt_re.exec(localpart);
     if (matches) {
         localpart = matches[1];
-        this.user = localpart.replace(exports.text_expr, '$1', 'g');
+        this.user = localpart.replace(exports.text_expr, '$1');
         return;
     }
     throw new Error('Invalid local part in address: ' + addr);
@@ -143,7 +143,7 @@ Address.prototype.format = function (use_punycode) {
         return '<>';
     }
 
-    const user = this.user.replace(qchar, '\\$1', 'g');
+    const user = this.user.replace(qchar, '\\$1');
     if (user !== this.user) {
         return '<"' + user + '"' + (this.original_host ? ('@' + (use_punycode ? this.host : this.original_host)) : '') + '>';
     }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const punycode = require('punycode');
 
 // a class encapsulating an email address per RFC-2821
 
-const qchar = /([^a-zA-Z0-9!#$%&\x27*+\x2D/=?^_`{|}~.\u0100-\uFFFF])/;
+const qchar = /([^a-zA-Z0-9!#$%&\x27*+\x2D/=?^_`{|}~.\u00C0-\uFFFF])/;
 
 function Address (user, host) {
     if (typeof user === 'object' && user.original) {
@@ -28,7 +28,7 @@ function Address (user, host) {
         this.user = user;
         this.original_host = host;
 
-        if (/[\u0100-\uFFFF]/.test(host)) {
+        if (/[\u00C0-\uFFFF]/.test(host)) {
             this.is_utf8 = true;
             host = punycode.toASCII(host);
         }
@@ -40,7 +40,7 @@ function Address (user, host) {
 
 const idn_allowed = require('./_idn');
 
-exports.atom_expr = /[a-zA-Z0-9!#%&*+=?^_`{|}~$\x27\x2D/\u0100-\uFFFF]+/;
+exports.atom_expr = /[a-zA-Z0-9!#%&*+=?^_`{|}~$\x27\x2D/\u00C0-\uFFFF]+/;
 exports.address_literal_expr =
   /(?:\[(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|IPv6:[0-9A-Fa-f:.]+)\])/;
 // exports.subdomain_expr = /(?:[a-zA-Z0-9](?:[_\-a-zA-Z0-9]*[a-zA-Z0-9])?)/;
@@ -50,7 +50,7 @@ exports.subdomain_expr = new RegExp('(?:' + idn_allowed.source + '(?:(?:[_-]|' +
 exports.domain_expr = undefined;
 
 /* eslint no-control-regex: 0 */
-exports.qtext_expr = /[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F\u0100-\uFFFF]/;
+exports.qtext_expr = /[\x01-\x08\x0B\x0C\x0E-\x1F\x21\x23-\x5B\x5D-\x7F\u00C0-\uFFFF]/;
 exports.text_expr  = /\\([\x01-\x09\x0B\x0C\x0E-\x7F])/;
 
 let domain_re;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "address-rfc2821",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "RFC 2821 (Envelope) email address parser",
   "author": {
     "name": "The Haraka Team",

--- a/test/address.js
+++ b/test/address.js
@@ -101,4 +101,17 @@ describe('format()', function () {
         assert.equal(addr.host, 'example.com');
         done();
     });
+    
+    it('no latin escaping', function (done) {
+        var addr = new Address('<přílišžluťoučkýkůň@přílišžluťoučkýkůň.cz>');
+        assert.equal(addr.format(), '<přílišžluťoučkýkůň@přílišžluťoučkýkůň.cz>');
+        done();
+    });
+
+    it('multiple escaped chars', function (done) {
+        var addr = new Address('<pří lišžlu ťoučkýkůň@přílišžluťoučkýkůň.cz>');
+        assert.equal(addr.format(), '<"pří\\ lišžlu\\ ťoučkýkůň"@přílišžluťoučkýkůň.cz>');
+        done();
+    });
+
 });


### PR DESCRIPTION
I have hit IDN problem when username contains unicode chars - all chars < \u0100 are escaped like this:

přílišžluťoučkýkůň@přílišžluťoučkýkůň.cz -> <"př\ílišžluťoučkýkůň"@přílišžluťoučkýkůň.cz>