### PR TITLE
add post-install script to compile grammar

### DIFF
--- a/.github/workflows/ci-test-win.yml
+++ b/.github/workflows/ci-test-win.yml
@@ -28,7 +28,6 @@ jobs:
     - name: npm install and test
       run: |
         npm install
-        npm run grammar
         npm run test
 
       env:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -28,9 +28,6 @@ jobs:
     - name: npm install
       run: npm install
 
-    - name: Compile grammar
-      run: npm run grammar
-
     - name: Run test suite
       run: npm run test
 

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -24,7 +24,6 @@ jobs:
       run: |
         npm install
         npm install --no-save nyc codecov
-        npm run grammar
         npm run cover
 
     - name: Coveralls

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "scripts": {
     "grammar": "npx nearleyc <grammar.ne -o grammar.js",
     "cover": "NODE_ENV=cov npx nyc --reporter=lcovonly npm run test",
-    "lint": "npx eslint *.js",
-    "lintfix": "npx eslint --fix *.js",
+    "lint": "npx eslint index.js test/*.js",
+    "lintfix": "npx eslint --fix index.js test/*.js",
     "postinstall": "npx nearleyc <grammar.ne -o grammar.js",
     "test": "npx mocha"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cover": "NODE_ENV=cov npx nyc --reporter=lcovonly npm run test",
     "lint": "npx eslint *.js",
     "lintfix": "npx eslint --fix *.js",
+    "postinstall": "npx nearleyc <grammar.ne -o grammar.js",
     "test": "npx mocha"
   },
   "repository": {


### PR DESCRIPTION
After installing this newer version, the module will fail because grammar.js won't yet exist. Compile `grammar.js` as part of the `npm install`. 