### PR TITLE
package.json: tell npx the nearly package name

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+.github
+logs
+*.log
+pids
+*.pid
+*.seed
+lib-cov
+coverage
+.grunt
+build/Release
+node_modules
+.lock-wscript
+package-lock.json
+grammar.js
+.eslintrc.yaml

--- a/Changes.md
+++ b/Changes.md
@@ -2,11 +2,12 @@
 ### 1.2.1 - 2021-01-01
 
 - The '+' character was mistakenly missing from atext/atom definition
+- package.json: tell npx the nearlyc package name
+
 
 ### 1.2.0 - 2020-12-25
 
-- Replace regular expression based parser with parser based on
-  <https://nearley.js.org/>
+- Replace regular expression based parser with parser based on <https://nearley.js.org/>
 - Double quote characters are not stripped from the local-part of the address if present.
 - No added escaping is attempted inside quoted-strings
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "cover": "NODE_ENV=cov npx nyc --reporter=lcovonly npm run test",
     "lint": "npx eslint index.js test/*.js",
     "lintfix": "npx eslint --fix index.js test/*.js",
-    "postinstall": "npx nearleyc <grammar.ne -o grammar.js",
+    "postinstall": "npx -p nearley nearleyc <grammar.ne -o grammar.js",
     "test": "npx mocha"
   },
   "repository": {


### PR DESCRIPTION
fixes #33 

I hope. If not, I'll try the `npx --no-install` option next. 