### PR TITLE
Fix nearleyc grammar

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "url": "https://github.com/haraka/node-address-rfc2821/issues"
   },
   "scripts": {
-    "grammar": "npx nearleyc <grammar.ne -o grammar.js",
+    "grammar": "npx nearleyc grammar.ne -o grammar.js",
     "cover": "NODE_ENV=cov npx nyc --reporter=lcovonly npm run test",
     "lint": "npx eslint index.js test/*.js",
     "lintfix": "npx eslint --fix index.js test/*.js",
-    "postinstall": "npx -p nearley nearleyc <grammar.ne -o grammar.js",
+    "postinstall": "npx -p nearley nearleyc grammar.ne -o grammar.js",
     "test": "npx mocha"
   },
   "repository": {


### PR DESCRIPTION
Docker container complaining about grammar file missing, node version is latest

```
error /usr/local/share/.config/yarn/global/node_modules/address-rfc2821: Command failed.
Exit code: 1
Command: npx -p nearley nearleyc <grammar.ne -o grammar.js
Arguments:
Directory: /usr/local/share/.config/yarn/global/node_modules/address-rfc2821
Output:
npm WARN exec The following package was not found and will be installed: nearley
/usr/local/share/.config/yarn/global/node_modules/nearley/lib/compile.js:25
        for (var i = 0; i < structure.length; i++) {
                                      ^

TypeError: Cannot read property 'length' of undefined
    at Compile (/usr/local/share/.config/yarn/global/node_modules/nearley/lib/compile.js:25:39)
    at StreamWrapper.<anonymous> (/usr/local/share/.config/yarn/global/node_modules/nearley/bin/nearleyc.js:32:17)
    at StreamWrapper.emit (node:events:388:22)
    at finish (node:internal/streams/writable:741:10)
    at processTicksAndRejections (node:internal/process/task_queues:80:21)
npm ERR! code 1
npm ERR! path /usr/local/share/.config/yarn/global/node_modules/address-rfc2821
npm ERR! command failed
npm ERR! command sh -c nearleyc -o grammar.js

npm ERR! A complete log of this run can be found in:
```

Thanks!