### PR TITLE
release 2.0.1

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,11 @@
 
+### 2.0.1 - 2021-01-21
+
+- grammer.ne: add polyfill for Array.flat (#43)
+- restore compatibility with Node < 12
+- restore node 10 testing
+
+
 ### 2.0.0 - 2021-01-05
 
 - major version bump, nearley output requires node.js > 11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "address-rfc2821",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "RFC-5321 (Envelope) email address parser",
   "author": {
     "name": "The Haraka Team",
@@ -23,7 +23,7 @@
     "url": "https://github.com/haraka/node-address-rfc2821/issues"
   },
   "engines": {
-    "node": ">= v12.20.1"
+    "node": ">= 10.23.1"
   },
   "scripts": {
     "grammar": "npx -p nearley nearleyc grammar.ne -o grammar.js",


### PR DESCRIPTION
- grammer.ne: add polyfill for Array.flat (#43)
- restore compatibility with Node < 12
- restore node 10 testing